### PR TITLE
lineItems duplicate fixed

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -185,7 +185,7 @@ class Profile(ViewSet):
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data
-                cart["order"]["line_items"] = line_items.data
+                cart["order"]["lineitems"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- In the response in profile.py the was cart["order"]["line_order"] that stood out as the red flag so I just removed the _ and now it works

## Requests / Responses


**Request**

GET
http://localhost:8000/profile/cart

**Response**


   >{
    "id": 10,
    "url": "http://localhost:8000/orders/10",
    "created_date": "2018-11-03",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/4",
    "lineitems": [
        {
            "id": 2,
            "product": {
                "id": 3,
                "name": "Durango",
                "price": 541.17,
                "number_sold": 0,
                "description": "1998 Dodge",
                "quantity": 2,
                "created_date": "2019-05-16",
                "location": "Górki Wielkie",
                "image_path": null,
                "average_rating": "No ratings yet"
            }
        }
    ],
    "size": 1
}

## Testing

Description of how to test code...

- [ ] postsman GET response
   >http://localhost:8000/profile/cart

- [ ] Response is correct
   >{
    "id": 10,
    "url": "http://localhost:8000/orders/10",
    "created_date": "2018-11-03",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/4",
    "lineitems": [
        {
            "id": 2,
            "product": {
                "id": 3,
                "name": "Durango",
                "price": 541.17,
                "number_sold": 0,
                "description": "1998 Dodge",
                "quantity": 2,
                "created_date": "2019-05-16",
                "location": "Górki Wielkie",
                "image_path": null,
                "average_rating": "No ratings yet"
            }
        }
    ],
    "size": 1
}
